### PR TITLE
WIP Remove selectedKey from public interface

### DIFF
--- a/packages/angular-playground/src/app.js
+++ b/packages/angular-playground/src/app.js
@@ -21,11 +21,9 @@ import moment from 'moment';
 
 angular
   .module('app', ['orion'])
-  .controller('Controller', ['$scope', function ($scope) {
-    var that = this;
-
-    $scope.clearable = true;
-    $scope.sizes = [
+  .controller('AppController', ['$scope', function ($scope) {
+    var app = this;
+    app.sizes = [
       { label: 'X-small', value: 'x-small', key: 0, disabled: true },
       { label: 'Small', value: 'small', key: 1 },
       { label: 'Medium', value: 'medium', key: 2 },
@@ -36,5 +34,4 @@ angular
     this.setSelectedIndex = (event) => {
       $scope.selectedIndex = event.detail.state.selectedIndex;
     }
-
   }]);

--- a/packages/angular-playground/src/index.html
+++ b/packages/angular-playground/src/index.html
@@ -28,8 +28,8 @@ limitations under the License.
   <body ng-app="app">
     <h1>Angular Playground</h1>
     <hr />
-    <div ng-controller="Controller as ctrl">
-      <orion-select searchable="clearable" clearable="clearable" options="sizes" on-change="ctrl.setSelectedIndex(event)"></orion-select>
+    <div ng-controller="AppController as app">
+      <orion-select on-change="app.setSelectedIndex(event)" selected-index="selectedIndex" searchable="true" clearable="true" options="app.sizes"></orion-select>
     </div>
   </body>
 </html>

--- a/packages/components/src/2016-12-01/select-state.js
+++ b/packages/components/src/2016-12-01/select-state.js
@@ -59,12 +59,11 @@ const SelectState = {
     if (nextSelectedKey === undefined) { nextSelectedKey = state.selectedKey; }
 
     const option = state.options.find(o => o.key === nextSelectedKey);
-    let selectedIndex;
+    let selectedIndex = -1;
     if (option) { selectedIndex = state.options.indexOf(option); }
 
     return {
       ...state,
-      selectedKey: nextSelectedKey,
       selectedIndex,
       filter: undefined,
       open: false,
@@ -195,7 +194,6 @@ const SelectState = {
     return {
       ...state,
       selectedIndex: -1,
-      selectedKey: undefined,
     };
   },
 };

--- a/packages/components/src/2016-12-01/select-state.test.js
+++ b/packages/components/src/2016-12-01/select-state.test.js
@@ -128,7 +128,7 @@ describe('SelectState', () => {
     });
 
     it('sets value to the selected option', () => {
-      expect(nextState.selectedKey).to.eq('b');
+      expect(nextState.selectedIndex).to.eq(1);
     });
 
     it('closes the menu', () => {
@@ -145,7 +145,7 @@ describe('SelectState', () => {
       });
 
       it('does not change the selectedKey', () => {
-        expect(nextState.selectedKey).to.eq('a');
+        expect(nextState.selectedIndex).to.eq(0);
       });
     });
   });
@@ -419,7 +419,6 @@ describe('SelectState', () => {
 
     it('clears the selectedKey and selectedIndex', () => {
       expect(nextState.selectedIndex).to.eq(-1);
-      expect(nextState.selectedKey).to.be.undefined;
     });
   });
 });

--- a/packages/components/src/2016-12-01/select.js
+++ b/packages/components/src/2016-12-01/select.js
@@ -84,14 +84,18 @@ class Select extends Element {
     this.state.selectedIndex = index;
     const option = this.state.options[index];
     if (option) {
-      this.selectedKey = option.key;
+      this.state.selectedKey = option.key;
     } else {
-      this.selectedKey = undefined;
+      this.state.selectedKey = undefined;
     }
+    this._queueRender();
   }
 
   set selectedKey(newValue) {
+    const selectedOption = this.state.options.find(option => option.key === newValue);
+    const selectedIndex = this.state.options.indexOf(selectedOption);
     this.state.selectedKey = newValue;
+    this.state.selectedIndex = selectedIndex;
     this._queueRender();
   }
 


### PR DESCRIPTION
@camwest This PR isn't ready to merge, unfortunately. 

The problem (for both #181 and #182) is that the state machine was passing back both `selectedKey` and `selectedIndex` and `selectedKey` took precedence. 

So say we have a select like this: 

```
<Select clearable={true} selectedIndex={1} />
```

Clicking the clear button would trigger a change event with both `selectedKey` and `selectedIndex` cleared. 
```
event.detail.state
=> { selectedKey: undefined, selectedIndex: -1 }
```

The wrapper would pass the 'frozen' `selectedIndex` value of `1`, but it would also pass the cleared `selectedKey` value. The internals of Select favored `selectedKey`, putting the component in an invalid state:
```
component.state
=> { selectedKey: undefined, selectedIndex: 1 } // This ain't right
```

This PR removes `selectedKey` from the public interface. I think this approach is the right direction, and it shows promise in the playground, but the interaction specs are failing and I've run out of time to fix them.
