### PR TITLE
fix insert between children issue

### DIFF
--- a/packages/react-hig/src/elements/HIGNodeList.js
+++ b/packages/react-hig/src/elements/HIGNodeList.js
@@ -19,15 +19,66 @@ limitations under the License.
  * Makes it simple to manage a list of child nodes within a react-hig element
  */
 export default class HIGNodeList {
-  constructor() {
+
+  constructor({ type, HIGConstructor, onAdd }) {
+    if (!type) {
+      throw new Error('type is required');
+    }
+
+    if (!HIGConstructor) {
+      throw new Error('HIGConstructor is required');
+    }
+
+    if (!onAdd) {
+      throw new Error('onInsert is required')
+    }
+
+    /**
+     * This is the constructor function for the HIGElement
+     */
+    this.type = type;
+
+    /**
+     * This is the constructor function for the hig.web partial
+     */
+    this.HIGConstructor = HIGConstructor;
+
+    /**
+     * This is a function which calls the hig add* method. It takes two hig instances
+     */
+    this.onAdd = onAdd;
+
     this.nodes = [];
+    this.mounted = false;
   }
 
-  appendChild(node) {
+  insertBefore(instance, insertBeforeIndex) {
+    if (!(instance instanceof this.type)) {
+      throw new Error(`unknown type ${instance}`);
+    }
+
+    // Update the model
+    const beforeChild = this._item(insertBeforeIndex);
+
+    if (beforeChild) {
+      this._insertBefore(instance, beforeChild);
+    } else {
+      this._appendChild(instance);
+    }
+
+    if (this.mounted) {
+      if (beforeChild) {
+        this.onAdd(instance.hig, beforeChild.hig);
+      } else {
+        this.onAdd(instance.hig);
+      }
+    }
+  }
+  _appendChild(node) {
     this.nodes.push(node);
   }
 
-  insertBefore(node, beforeNode) {
+  _insertBefore(node, beforeNode) {
     const index = this.nodes.indexOf(beforeNode);
     this.nodes.splice(index, 0, node);
   }
@@ -35,21 +86,28 @@ export default class HIGNodeList {
   removeChild(node) {
     const index = this.nodes.indexOf(node);
     this.nodes.splice(index, 1);
+    node.unmount();
   }
 
-  item(index) {
+  _item(index) {
     return this.nodes[index];
   }
 
-  [Symbol.iterator]() {
-    var nextIndex = 0;
+  componentDidMount() {
+    this.nodes.forEach(node => {
+      this.onAdd(node.hig);
+      node.mount();
+    });
 
-    return {
-      next: () => {
-        return nextIndex < this.nodes.length
-          ? { value: this.nodes[nextIndex++], done: false }
-          : { done: true };
-      }
-    };
+    this.mounted = true;
+  }
+
+  createElement(ElementConstructor, props) {
+    switch (ElementConstructor) {
+      case this.type:
+        return new this.type(this.HIGConstructor, props);
+      default:
+        throw new Error(`Unknown type ${ElementConstructor.name}`);
+    }
   }
 }

--- a/packages/react-hig/src/elements/HIGNodeList.js
+++ b/packages/react-hig/src/elements/HIGNodeList.js
@@ -19,7 +19,6 @@ limitations under the License.
  * Makes it simple to manage a list of child nodes within a react-hig element
  */
 export default class HIGNodeList {
-
   constructor({ type, HIGConstructor, onAdd }) {
     if (!type) {
       throw new Error('type is required');
@@ -30,7 +29,7 @@ export default class HIGNodeList {
     }
 
     if (!onAdd) {
-      throw new Error('onInsert is required')
+      throw new Error('onInsert is required');
     }
 
     /**

--- a/packages/react-hig/src/elements/components/GlobalNav/Group.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Group.js
@@ -23,49 +23,29 @@ import ItemComponent, { Item } from './Item';
 export class Group extends HIGElement {
   constructor(HIGConstructor, initialProps) {
     super(HIGConstructor, initialProps);
-    // items that get appended before mounting
-    this.items = new HIGNodeList();
+    this.items = new HIGNodeList({
+      type: Item,
+      HIGConstructor: this.hig.partials.Item,
+      onAdd: (instance, beforeInstance) => {
+        this.hig.addItem(instance, beforeInstance);
+      }
+    });
   }
 
   componentDidMount() {
-    for (let instance of this.items) {
-      this.hig.addItem(instance.hig);
-      instance.mount();
-    }
+    this.items.componentDidMount();
   }
 
   createElement(ElementConstructor, props) {
-    switch (ElementConstructor) {
-      case Item:
-        return new Item(this.hig.partials.Item, props);
-      default:
-        throw new Error(`Unknown type ${ElementConstructor.name}`);
-    }
-  }
-
-  appendChild(instance) {
-    if (instance instanceof Item) {
-      this.items.appendChild(instance);
-
-      if (this.mounted) {
-        this.hig.addItem(instance.hig);
-        instance.mount();
-      }
-    } else {
-      throw new Error('unknown type');
-    }
+    return this.items.createElement(ElementConstructor, props);
   }
 
   insertBefore(instance, insertBeforeIndex) {
-    const beforeChild = this.items.item(insertBeforeIndex);
-    this.items.insertBefore(instance, beforeChild);
-    this.hig.addItem(instance.hig, beforeChild.hig);
-    instance.mount();
+    this.items.insertBefore(instance, insertBeforeIndex);
   }
 
   removeChild(instance) {
     this.items.removeChild(instance);
-    instance.unmount();
   }
 }
 

--- a/packages/react-hig/src/elements/components/GlobalNav/LinkList.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/LinkList.js
@@ -23,16 +23,17 @@ import LinkComponent, { Link } from './Link';
 export class LinkList {
   constructor(higInstance) {
     this.hig = higInstance;
-    this.links = new HIGNodeList();
+    this.links = new HIGNodeList({
+      type: Link,
+      HIGConstructor: this.hig.partials.Link,
+      onAdd: (instance, beforeInstance) => {
+        this.hig.addLink(instance, beforeInstance);
+      }
+    });
   }
 
   mount() {
-    this.mounted = true;
-
-    for (let instance of this.links) {
-      this.hig.addSection(instance.hig);
-      instance.mount();
-    }
+    this.links.componentDidMount();
   }
 
   unmount() {
@@ -44,38 +45,15 @@ export class LinkList {
   }
 
   createElement(ElementConstructor, props) {
-    switch (ElementConstructor) {
-      case Link:
-        return new Link(this.hig.partials.Link, props);
-      default:
-        throw new Error(`Unknown type ${ElementConstructor.name}`);
-    }
-  }
-
-  appendChild(instance) {
-    if (instance instanceof Link) {
-      this.links.appendChild(instance);
-
-      if (this.mounted) {
-        this.hig.addLink(instance.hig);
-        instance.mount();
-      }
-    } else {
-      throw new Error(`unknown type ${instance}`);
-    }
+    return this.links.createElement(ElementConstructor, props);
   }
 
   insertBefore(instance, insertBeforeIndex) {
-    const beforeChild = this.links.item(insertBeforeIndex);
-    this.links.insertBefore(instance, beforeChild);
-    this.hig.addLink(instance.hig, beforeChild.hig);
-    instance.mount();
+    this.links.insertBefore(instance, insertBeforeIndex);
   }
 
   removeChild(instance) {
-    const index = this.links.indexOf(instance);
-    this.links.splice(index, 1);
-    instance.unmount();
+    this.links.removeChild(instance);
   }
 }
 

--- a/packages/react-hig/src/elements/components/GlobalNav/Section.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Section.js
@@ -25,14 +25,17 @@ import GroupComponent, { Group } from './Group';
 export class Section extends HIGElement {
   constructor(HIGConstructor, initialProps) {
     super(HIGConstructor, initialProps);
-    this.groups = new HIGNodeList();
+    this.groups = new HIGNodeList({
+      type: Group,
+      HIGConstructor: this.hig.partials.Group,
+      onAdd: (instance, beforeInstance) => {
+        this.hig.addGroup(instance, beforeInstance);
+      }
+    });
   }
 
   componentDidMount() {
-    for (let instance of this.groups) {
-      this.hig.addGroup(instance.hig);
-      instance.mount();
-    }
+    this.groups.componentDidMount();
   }
 
   commitUpdate(updatePayload, oldProps, newProp) {
@@ -58,37 +61,15 @@ export class Section extends HIGElement {
   }
 
   createElement(ElementConstructor, props) {
-    switch (ElementConstructor) {
-      case Group:
-        return new Group(this.hig.partials.Group, props);
-      default:
-        throw new Error(`Unknown type ${ElementConstructor.name}`);
-    }
-  }
-
-  appendChild(instance) {
-    if (instance instanceof Group) {
-      this.groups.appendChild(instance);
-
-      if (this.mounted) {
-        this.hig.addGroup(instance.hig);
-        instance.mount();
-      }
-    } else {
-      throw new Error(`unknown type ${instance}`);
-    }
+    return this.groups.createElement(ElementConstructor, props);
   }
 
   insertBefore(instance, insertBeforeIndex) {
-    const beforeChild = this.groups.item(insertBeforeIndex);
-    this.groups.insertBefore(instance, beforeChild);
-    this.hig.addGroup(instance.hig, beforeChild.hig);
-    instance.mount();
+    this.groups.insertBefore(instance, insertBeforeIndex);
   }
 
   removeChild(instance) {
     this.groups.removeChild(instance);
-    instance.unmount();
   }
 }
 

--- a/packages/react-hig/src/elements/components/GlobalNav/SectionList.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/SectionList.js
@@ -24,16 +24,17 @@ import SectionComponent, { Section } from './Section';
 export class SectionList {
   constructor(higInstance) {
     this.hig = higInstance;
-    this.sections = new HIGNodeList();
+    this.sections = new HIGNodeList({
+      type: Section,
+      HIGConstructor: this.hig.partials.Section,
+      onAdd: (instance, beforeInstance) => {
+        this.hig.addSection(instance, beforeInstance);
+      }
+    });
   }
 
   mount() {
-    this.mounted = true;
-
-    for (let instance of this.sections) {
-      this.hig.addSection(instance.hig);
-      instance.mount();
-    }
+    this.sections.componentDidMount();
   }
 
   unmount() {
@@ -45,37 +46,15 @@ export class SectionList {
   }
 
   createElement(ElementConstructor, props) {
-    switch (ElementConstructor) {
-      case Section:
-        return new Section(this.hig.partials.Section, props);
-      default:
-        throw new Error(`Unknown type ${ElementConstructor.name}`);
-    }
-  }
-
-  appendChild(instance) {
-    if (instance instanceof Section) {
-      this.sections.appendChild(instance);
-
-      if (this.mounted) {
-        this.hig.addSection(instance.hig);
-        instance.mount();
-      }
-    } else {
-      throw new Error(`unknown type ${instance}`);
-    }
+    return this.sections.createElement(ElementConstructor, props);
   }
 
   insertBefore(instance, insertBeforeIndex) {
-    const beforeChild = this.sections.item(insertBeforeIndex);
-    this.sections.insertBefore(instance, beforeChild);
-    this.hig.addSection(instance.hig, beforeChild.hig);
-    instance.mount();
+    this.sections.insertBefore(instance, insertBeforeIndex);
   }
 
   removeChild(instance) {
     this.sections.removeChild(instance);
-    instance.unmount();
   }
 }
 

--- a/packages/react-hig/src/elements/components/GlobalNav/Tabs.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Tabs.js
@@ -25,51 +25,29 @@ import TabComponent, { Tab } from './Tab';
 export class Tabs extends HIGElement {
   constructor(HigContructor, initialProps) {
     super(HigContructor, initialProps);
-    this.tabs = new HIGNodeList();
+    this.tabs = new HIGNodeList({
+      type: Tab,
+      HIGConstructor: this.hig.partials.Tab,
+      onAdd: (instance, beforeInstance) => {
+        this.hig.addTab(instance, beforeInstance);
+      }
+    });
   }
 
   componentDidMount() {
-    for (let instance of this.tabs) {
-      this.hig.addTab(instance.hig);
-      instance.mount();
-    }
+    this.tabs.componentDidMount();
   }
 
   createElement(ElementConstructor, props) {
-    switch (ElementConstructor) {
-      case Tab:
-        return new Tab(this.hig.partials.Tab, props);
-      case 'children':
-        /* no-op */
-        break;
-      default:
-        throw new Error(`Unknown type ${ElementConstructor.name}`);
-    }
-  }
-
-  appendChild(instance) {
-    if (instance instanceof Tab) {
-      this.tabs.appendChild(instance);
-
-      if (this.mounted) {
-        this.hig.addTab(instance.hig);
-        instance.mount();
-      }
-    } else {
-      throw new Error(`unknown type ${instance}`);
-    }
+    return this.tabs.createElement(ElementConstructor, props);
   }
 
   insertBefore(instance, insertBeforeIndex) {
-    const beforeChild = this.tabs.item(insertBeforeIndex);
-    this.tabs.insertBefore(instance, beforeChild);
-    this.hig.addTab(instance.hig, beforeChild.hig);
-    instance.mount();
+    this.tabs.insertBefore(instance, insertBeforeIndex);
   }
 
   removeChild(instance) {
     this.tabs.removeChild(instance);
-    instance.unmount();
   }
 }
 

--- a/packages/react-hig/src/elements/components/GlobalNav/Tabs.test.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Tabs.test.js
@@ -49,7 +49,7 @@ describe('<Tabs>', () => {
 
   it('adds tabs', () => {
     const initialTabs = ['Hello', 'World'];
-    const updatedTabs = ['Well', 'Hello', 'World', '!'];
+    const updatedTabs = ['Hello', 'There', 'World', '!'];
     const reactContainer = document.createElement('div');
     const wrapper = mount(<Context tabs={initialTabs} />, {
       attachTo: reactContainer

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tabs.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tabs.test.js.snap
@@ -9,7 +9,7 @@ exports[`<Tabs> adds tabs 1`] = `
     <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
     <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
-    <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Well</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Hello</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">World</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">!</div><!--TAB-->
+    <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Hello</div><div class=\\"hig__global-nav__sub-nav__tabs__tab \\">There</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">World</div><div class=\\"hig__global-nav__sub-nav__tabs__tab \\">!</div><!--TAB-->
 </div><!--TABS-->
     <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
     <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>


### PR DESCRIPTION
Fixes #222 

## Description

* change createComponent to only swap for an html comment if it is the top level React Component
* change createComponent to always use insertBefore lifecycle method if it is available
* change HIGNodeList to manage the whole child lifecycle instead of only half of it
* change Group, LinkList, Section, SectionList and Tabs to delegate to HIGNodeList methods

## Motivation and Context

Previously we were swapping the created react DOM instance with an HTML comment to keep the document free from extraneous divs. This was causing a problem in the React stack renderer here: https://github.com/facebook/react/blob/b1768b5a48d1f82e4ef4150e0036c5f846d3758a/src/renderers/dom/stack/client/DOMChildrenOperations.js#L48 because insertBefore was inserting the DOM elements incorrectly (with an orphaned element reference)

Now we only swap for html comment anchors for the first HTML element in the HIG context. Lower level components do not do this so that React can reconcile children relative to each other correctly. This means that React is reconciling on an orphaned fragment of DOM elements, but it works fine!

The second piece of code here improves the HIGNodeList to manage the entire child node lifecycle. This means it's easy to create a collection of children in a component just by delegating certain methods to the HIGNodeList.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I added a new test for inserting a child node in between two other nodes in the Tabs.test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.