### PR TITLE
Fix mounting issues in TopNav & update HIG.web version

### DIFF
--- a/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.js
@@ -35,17 +35,17 @@ class GlobalNav extends HIGElement {
     // Add any children
     if (this.sideNav) {
       this.hig.addSideNav(this.sideNav.hig);
-      this.sideNav.componentDidMount();
+      this.sideNav.mount();
     }
 
     if (this.topNav) {
       this.hig.addTopNav(this.topNav.hig);
-      this.topNav.componentDidMount();
+      this.topNav.mount();
     }
 
     if (this.subNav) {
       this.hig.addSubNav(this.subNav.hig);
-      this.subNav.componentDidMount();
+      this.subNav.mount();
     }
 
     if (this.initialProps.sideNavOpen) {
@@ -80,7 +80,7 @@ class GlobalNav extends HIGElement {
         this.sideNav = instance;
         if (this.mounted) {
           this.hig.addSideNav(instance.hig);
-          instance.componentDidMount();
+          instance.mount();
         }
       }
     } else if (instance instanceof TopNav) {
@@ -90,7 +90,7 @@ class GlobalNav extends HIGElement {
         this.topNav = instance;
         if (this.mounted) {
           this.hig.addTopNav(instance.hig);
-          instance.componentDidMount();
+          instance.mount();
         }
       }
     } else if (instance instanceof SubNav) {
@@ -100,7 +100,7 @@ class GlobalNav extends HIGElement {
         this.subNav = instance;
         if (this.mounted) {
           this.hig.addSubNav(instance.hig);
-          instance.componentDidMount();
+          instance.mount();
         }
       }
     } else {

--- a/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
@@ -34,13 +34,15 @@ export class TopNav extends HIGElement {
     const mapping = {
       logo: 'setLogo',
       logoLink: 'setLogoLink'
-    }
+    };
 
     for (let i = 0; i < updatePayload.length; i += 2) {
       const propKey = updatePayload[i];
       const propValue = updatePayload[i + 1];
 
-      if (propKey === 'children') { break }
+      if (propKey === 'children') {
+        break;
+      }
 
       if (mapping[propKey]) {
         this.hig[mapping[propKey]](propValue);

--- a/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
@@ -31,36 +31,21 @@ export class TopNav extends HIGElement {
   }
 
   commitUpdate(updatePayload, oldProps, newProp) {
+    const mapping = {
+      logo: 'setLogo',
+      logoLink: 'setLogoLink'
+    }
+
     for (let i = 0; i < updatePayload.length; i += 2) {
       const propKey = updatePayload[i];
       const propValue = updatePayload[i + 1];
 
-      switch (propKey) {
-        case 'logo':
-          this.hig.setLogo(propValue);
-          break;
-        case 'logoLink':
-          this.hig.setLogoLink(propValue);
-          break;
-        case 'children':
-          // No-op
-          break;
-        case 'onHamburgerClick': {
-          const dispose = this._disposeFunctions.get('onHamburgerClickDispose');
+      if (propKey === 'children') { break }
 
-          if (dispose) {
-            dispose();
-          }
-
-          this._disposeFunctions.set(
-            'onHamburgerClickDispose',
-            this.hig.onHamburgerClick(propValue)
-          );
-          break;
-        }
-        default: {
-          console.warn(`${propKey} is unknown`);
-        }
+      if (mapping[propKey]) {
+        this.hig[mapping[propKey]](propValue);
+      } else {
+        this.commitPropChange(propKey, propValue);
       }
     }
   }

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/GlobalNav.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/GlobalNav.test.js.snap
@@ -6,7 +6,7 @@ exports[`<GlobalNav> can render the Container as a child 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -19,7 +19,7 @@ exports[`<GlobalNav> renders the global nav 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -38,7 +38,7 @@ exports[`<GlobalNav> sideNavOpen prop can render the SideNav as a child 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -51,7 +51,7 @@ exports[`<GlobalNav> sideNavOpen prop can showSideNav by default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -64,7 +64,7 @@ exports[`<GlobalNav> sideNavOpen prop is equal to showSideNav 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -77,7 +77,7 @@ exports[`<GlobalNav> sideNavOpen prop is equal to showSideNav 2`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Group.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Group.test.js.snap
@@ -25,7 +25,7 @@ exports[`<Group> children: <Item> can insert <Item> elements before and after an
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -62,7 +62,7 @@ exports[`<Group> children: <Item> can insert <Item> elements before and after an
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -94,7 +94,7 @@ exports[`<Group> children: <Item> can insert <Item> elements before and after an
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -131,7 +131,7 @@ exports[`<Group> children: <Item> can insert <Item> elements before and after an
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -163,7 +163,7 @@ exports[`<Group> children: <Item> can insert <Item> elements before and after an
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -200,7 +200,7 @@ exports[`<Group> children: <Item> can render a list of <Item> elements 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Item.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Item.test.js.snap
@@ -25,7 +25,7 @@ exports[`<Item> icon sets icon by default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -57,7 +57,7 @@ exports[`<Item> icon updates icon 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -89,7 +89,7 @@ exports[`<Item> link sets link by default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -121,7 +121,7 @@ exports[`<Item> link updates link 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -153,7 +153,7 @@ exports[`<Item> title sets title by default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -185,7 +185,7 @@ exports[`<Item> title updates title 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Section.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Section.test.js.snap
@@ -20,7 +20,7 @@ exports[`<Section> children: <Group> can insert <Group> elements before and afte
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -49,7 +49,7 @@ exports[`<Section> children: <Group> can insert <Group> elements before and afte
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -76,7 +76,7 @@ exports[`<Section> children: <Group> can insert <Group> elements before and afte
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -105,7 +105,7 @@ exports[`<Section> children: <Group> can insert <Group> elements before and afte
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -132,7 +132,7 @@ exports[`<Section> children: <Group> can insert <Group> elements before and afte
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -161,7 +161,7 @@ exports[`<Section> children: <Group> can render a list of <Group> elements 1`] =
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -186,7 +186,7 @@ exports[`<Section> headerLabel sets the headerLabel default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -211,7 +211,7 @@ exports[`<Section> headerLabel updates the headerLabel 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -236,7 +236,7 @@ exports[`<Section> headerName sets the headerName default 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -261,7 +261,7 @@ exports[`<Section> headerName updates the headerName 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SectionList.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SectionList.test.js.snap
@@ -18,7 +18,7 @@ exports[`<SectionList> can insert a <Section> before and after another <Section>
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -49,7 +49,7 @@ exports[`<SectionList> can insert a <Section> before and after another <Section>
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -74,7 +74,7 @@ exports[`<SectionList> can insert a <Section> before and after another <Section>
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -105,7 +105,7 @@ exports[`<SectionList> can insert a <Section> before and after another <Section>
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -130,7 +130,7 @@ exports[`<SectionList> can insert a <Section> before and after another <Section>
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -161,7 +161,7 @@ exports[`<SectionList> can render a list of <Section> elements 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SideNav.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SideNav.test.js.snap
@@ -12,7 +12,7 @@ exports[`<SideNav> can render a LinksList as a child 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -31,7 +31,7 @@ exports[`<SideNav> can render a SectionList as a child 1`] = `
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SubNav.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/SubNav.test.js.snap
@@ -5,14 +5,16 @@ exports[`<SubNav> adds and removes tabs 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Documents Library</div>
-    <!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Documents Library</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Documents Library</div>
+    <div class=\\"hig__global-nav__sub-nav__tabs\\">
+    <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Things</div><!--TAB-->
+</div><!--TABS-->
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Documents Library</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -24,14 +26,14 @@ exports[`<SubNav> adds and removes tabs 2`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Documents Library</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Documents Library</div>
     <!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Documents Library</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Documents Library</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -43,14 +45,14 @@ exports[`<SubNav> renders with props 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Documents Library</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Documents Library</div>
     <!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">hamburger</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Documents Library</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">hamburger</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Documents Library</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -62,14 +64,14 @@ exports[`<SubNav> updates props 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\"><svg width=\\"20\\" height=\\"21\\" viewBox=\\"0 0 20 21\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"project-management\\"><g transform=\\"translate(.242)\\" fill=\\"#34495E\\" fill-rule=\\"evenodd\\"><path d=\\"M15,8.15002717 C14.6738533,8.08382289 14.3400214,8.03878262 14,8.01640228 L14,1 L1,1 L1,17 L6.15002717,17 C6.21952655,17.3423796 6.31234911,17.6762897 6.42676427,18 L0,18 L0,0 L15,0 L15,8.15002717 Z M8.40093151,10 C8.07157864,10.3054873 7.76971094,10.6401947 7.49945072,11 L3,11 L3,10 L8.40093151,10 Z M6.42676427,13 C6.31234911,13.3237103 6.21952655,13.6576204 6.15002717,14 L3,14 L3,13 L6.42676427,13 Z M3,4 L12,4 L12,5 L3,5 L3,4 Z M3,7 L12,7 L12,8 L3,8 L3,7 Z\\" fill-rule=\\"nonzero\\"></path><path d=\\"M13.5,20 C15.9852814,20 18,17.9852814 18,15.5 C18,13.0147186 15.9852814,11 13.5,11 C11.0147186,11 9,13.0147186 9,15.5 C9,17.9852814 11.0147186,20 13.5,20 Z M13.5,21 C10.4624339,21 8,18.5375661 8,15.5 C8,12.4624339 10.4624339,10 13.5,10 C16.5375661,10 19,12.4624339 19,15.5 C19,18.5375661 16.5375661,21 13.5,21 Z\\" fill-rule=\\"nonzero\\"></path><rect x=\\"13\\" y=\\"12\\" width=\\"1\\" height=\\"4\\"></rect><rect x=\\"13\\" y=\\"15\\" width=\\"4\\" height=\\"1\\"></rect></g></svg></div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Projects Library</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\"><svg width=\\"20\\" height=\\"21\\" viewBox=\\"0 0 20 21\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"project-management\\"><g transform=\\"translate(.242)\\" fill=\\"#34495E\\" fill-rule=\\"evenodd\\"><path d=\\"M15,8.15002717 C14.6738533,8.08382289 14.3400214,8.03878262 14,8.01640228 L14,1 L1,1 L1,17 L6.15002717,17 C6.21952655,17.3423796 6.31234911,17.6762897 6.42676427,18 L0,18 L0,0 L15,0 L15,8.15002717 Z M8.40093151,10 C8.07157864,10.3054873 7.76971094,10.6401947 7.49945072,11 L3,11 L3,10 L8.40093151,10 Z M6.42676427,13 C6.31234911,13.3237103 6.21952655,13.6576204 6.15002717,14 L3,14 L3,13 L6.42676427,13 Z M3,4 L12,4 L12,5 L3,5 L3,4 Z M3,7 L12,7 L12,8 L3,8 L3,7 Z\\" fill-rule=\\"nonzero\\"></path><path d=\\"M13.5,20 C15.9852814,20 18,17.9852814 18,15.5 C18,13.0147186 15.9852814,11 13.5,11 C11.0147186,11 9,13.0147186 9,15.5 C9,17.9852814 11.0147186,20 13.5,20 Z M13.5,21 C10.4624339,21 8,18.5375661 8,15.5 C8,12.4624339 10.4624339,10 13.5,10 C16.5375661,10 19,12.4624339 19,15.5 C19,18.5375661 16.5375661,21 13.5,21 Z\\" fill-rule=\\"nonzero\\"></path><rect x=\\"13\\" y=\\"12\\" width=\\"1\\" height=\\"4\\"></rect><rect x=\\"13\\" y=\\"15\\" width=\\"4\\" height=\\"1\\"></rect></g></svg></div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Projects Library</div>
     <!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\"><svg width=\\"20\\" height=\\"21\\" viewBox=\\"0 0 20 21\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"project-management\\"><g transform=\\"translate(.242)\\" fill=\\"#34495E\\" fill-rule=\\"evenodd\\"><path d=\\"M15,8.15002717 C14.6738533,8.08382289 14.3400214,8.03878262 14,8.01640228 L14,1 L1,1 L1,17 L6.15002717,17 C6.21952655,17.3423796 6.31234911,17.6762897 6.42676427,18 L0,18 L0,0 L15,0 L15,8.15002717 Z M8.40093151,10 C8.07157864,10.3054873 7.76971094,10.6401947 7.49945072,11 L3,11 L3,10 L8.40093151,10 Z M6.42676427,13 C6.31234911,13.3237103 6.21952655,13.6576204 6.15002717,14 L3,14 L3,13 L6.42676427,13 Z M3,4 L12,4 L12,5 L3,5 L3,4 Z M3,7 L12,7 L12,8 L3,8 L3,7 Z\\" fill-rule=\\"nonzero\\"></path><path d=\\"M13.5,20 C15.9852814,20 18,17.9852814 18,15.5 C18,13.0147186 15.9852814,11 13.5,11 C11.0147186,11 9,13.0147186 9,15.5 C9,17.9852814 11.0147186,20 13.5,20 Z M13.5,21 C10.4624339,21 8,18.5375661 8,15.5 C8,12.4624339 10.4624339,10 13.5,10 C16.5375661,10 19,12.4624339 19,15.5 C19,18.5375661 16.5375661,21 13.5,21 Z\\" fill-rule=\\"nonzero\\"></path><rect x=\\"13\\" y=\\"12\\" width=\\"1\\" height=\\"4\\"></rect><rect x=\\"13\\" y=\\"15\\" width=\\"4\\" height=\\"1\\"></rect></g></svg></div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Projects Library</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\"><svg width=\\"20\\" height=\\"21\\" viewBox=\\"0 0 20 21\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"project-management\\"><g transform=\\"translate(.242)\\" fill=\\"#34495E\\" fill-rule=\\"evenodd\\"><path d=\\"M15,8.15002717 C14.6738533,8.08382289 14.3400214,8.03878262 14,8.01640228 L14,1 L1,1 L1,17 L6.15002717,17 C6.21952655,17.3423796 6.31234911,17.6762897 6.42676427,18 L0,18 L0,0 L15,0 L15,8.15002717 Z M8.40093151,10 C8.07157864,10.3054873 7.76971094,10.6401947 7.49945072,11 L3,11 L3,10 L8.40093151,10 Z M6.42676427,13 C6.31234911,13.3237103 6.21952655,13.6576204 6.15002717,14 L3,14 L3,13 L6.42676427,13 Z M3,4 L12,4 L12,5 L3,5 L3,4 Z M3,7 L12,7 L12,8 L3,8 L3,7 Z\\" fill-rule=\\"nonzero\\"></path><path d=\\"M13.5,20 C15.9852814,20 18,17.9852814 18,15.5 C18,13.0147186 15.9852814,11 13.5,11 C11.0147186,11 9,13.0147186 9,15.5 C9,17.9852814 11.0147186,20 13.5,20 Z M13.5,21 C10.4624339,21 8,18.5375661 8,15.5 C8,12.4624339 10.4624339,10 13.5,10 C16.5375661,10 19,12.4624339 19,15.5 C19,18.5375661 16.5375661,21 13.5,21 Z\\" fill-rule=\\"nonzero\\"></path><rect x=\\"13\\" y=\\"12\\" width=\\"1\\" height=\\"4\\"></rect><rect x=\\"13\\" y=\\"15\\" width=\\"4\\" height=\\"1\\"></rect></g></svg></div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Projects Library</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tab.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tab.test.js.snap
@@ -5,16 +5,16 @@ exports[`<Tab> renders a tab 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
     <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Such Tab</div><!--TAB-->
 </div><!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Module Name</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -26,16 +26,16 @@ exports[`<Tab> updates props 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
     <div class=\\"hig__global-nav__sub-nav__tabs__tab hig__global-nav__sub-nav__tabs__tab--active\\" title=\\"Many Tab\\">Many Tab</div><!--TAB-->
 </div><!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Module Name</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tabs.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Tabs.test.js.snap
@@ -5,16 +5,16 @@ exports[`<Tabs> adds tabs 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
     <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Hello</div><div class=\\"hig__global-nav__sub-nav__tabs__tab \\">There</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">World</div><div class=\\"hig__global-nav__sub-nav__tabs__tab \\">!</div><!--TAB-->
 </div><!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Module Name</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -26,16 +26,16 @@ exports[`<Tabs> removes tabs 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
     <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">World</div><!--TAB-->
 </div><!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Module Name</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>
@@ -47,16 +47,16 @@ exports[`<Tabs> renders tabs 1`] = `
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
         <!--TOPNAV-->
-        <div class=\\"hig__global-nav__container__sub-nav\\">
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left\\">Module Name</div>
+        <div class=\\"hig__global-nav__sub-nav\\">
+    <div class=\\"hig__global-nav__sub-nav__left__icon\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left\\">Module Name</div>
     <div class=\\"hig__global-nav__sub-nav__tabs\\">
     <div class=\\"hig__global-nav__sub-nav__tabs__tab\\">Hello</div><div class=\\"hig__global-nav__sub-nav__tabs__tab\\">World</div><!--TAB-->
 </div><!--TABS-->
-    <div class=\\"hig__global-nav__container__sub-nav__left__icon hig__global-nav__container__sub-nav__spacer\\">#</div>
-    <div class=\\"hig__global-nav__container__sub-nav__left hig__global-nav__container__sub-nav__spacer\\">Module Name</div>
+    <div class=\\"hig__global-nav__sub-nav__left__icon hig__global-nav__sub-nav__spacer\\">#</div>
+    <div class=\\"hig__global-nav__sub-nav__left hig__global-nav__sub-nav__spacer\\">Module Name</div>
 </div><!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/TopNav.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/TopNav.test.js.snap
@@ -4,26 +4,26 @@ exports[`<TopNav> renders a topnav 1`] = `
 "<div class=\\"hig__global-nav\\">
     <!--SIDENAV-->
     <div class=\\"hig__global-nav__container\\">
-        <div class=\\"hig__global-nav__container__top-nav\\">
-    <div class=\\"hig__global-nav__container__top-nav__group hig__global-nav__container__top-nav__group--left\\">
-        <div class=\\"hig__global-nav__container__top-nav__hamburger js-hig__global-nav__container__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
-        <div class=\\"hig__global-nav__container__top-nav__logo\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
             <a href=\\"http://www.autodesk.com\\">
                 <img src=\\"../../../bim-logo.png\\">
             </a>
         </div>
     </div>
-    <div class=\\"hig__global-nav__profile hig__global-nav__container__top-nav__group--right\\">
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
     <!--FLYOUT-->
 <div class=\\"hig__flyout\\">
-    <div class=\\"hig__global-nav__container__top-nav__profile__profile-image\\">
-    <img class=\\"hig__global-nav__container__top-nav__profile__profile-image__image\\" src=\\"../../../bim-logo.png\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"../../../bim-logo.png\\">
 </div><!--TARGET-->
     <div class=\\"hig__flyout__container\\">
-        <div class=\\"src__components__global-nav__container__top-nav__profile__profile-flyout-content\\">
-    <div class=\\"src__components__global-nav__container__top-nav__profile__profile-flyout-content__name\\"></div>
-    <div class=\\"src__components__global-nav__container__top-nav__profile__profile-flyout-content__email\\"></div>
-    <div class=\\"src__components__global-nav__container__top-nav__profile__profile-flyout-content__links\\">
+        <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\"></div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\"></div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
         <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
@@ -32,7 +32,7 @@ exports[`<TopNav> renders a topnav 1`] = `
 </div></div><!--PROFILE-->
 </div><!--TOPNAV-->
         <!--SUBNAV-->
-        <div class=\\"hig__global-nav__container__slot\\">
+        <div class=\\"hig__global-nav__slot\\">
             <!--SLOT-->
         </div>
     </div>

--- a/packages/react-hig/src/index.js
+++ b/packages/react-hig/src/index.js
@@ -57,7 +57,7 @@ class App extends React.Component {
     });
   };
 
-  handleClick = event => {
+  toggleSideNav = event => {
     this.setState({ open: !this.state.open });
   };
 
@@ -141,7 +141,7 @@ class App extends React.Component {
           <TopNav
             logo={logo}
             logoLink="http://autodesk.com"
-            onHamburgerClick={this.handleClick}
+            onHamburgerClick={this.toggleSideNav}
           >
             <Profile
               image={profileImage}


### PR DESCRIPTION
Update to latest version of HIG.web
- Removes references to `container` from classnames

Mount sub components of GlobalNav correctly so event listeners are attached properly.