### PR TITLE
Improve test coverage and setter shared example

### DIFF
--- a/packages/react-hig/src/elements/components/GlobalNav/Profile.test.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Profile.test.js
@@ -90,7 +90,7 @@ describe('<Profile>', () => {
     const configSets = [
       {
         key: 'email',
-        sampleValue: 'foo@bar.baz',
+        sampleValue: 'foo@example.com',
         updateValue: 'hellokitty@example.com',
         mutator: 'setEmail'
       },
@@ -103,9 +103,28 @@ describe('<Profile>', () => {
       {
         key: 'image',
         sampleValue: '/images/foo.jpg',
-        updateValue: '/images/bar.jpg',
+        updateValue: '/images/BAR.PNG',
         mutator: 'setImage'
-      }
+      },
+      {
+        key: 'signOutLabel',
+        sampleValue: 'Logout',
+        updateValue: 'Sign Out',
+        mutator: 'setSignOutLabel'
+      },
+      {
+        key: 'profileSettingsLabel',
+        sampleValue: 'Settings',
+        updateValue: 'Preferences',
+        mutator: 'setProfileSettingsLabel'
+      },
+      {
+        key: 'profileSettingsLink',
+        sampleValue: 'http://www.google.com',
+        updateValue: 'http://www.sanrio.com',
+        mutator: 'setProfileSettingsLink'
+      },
+
     ];
 
     configSets.forEach(function(config) {

--- a/packages/react-hig/src/elements/components/GlobalNav/Profile.test.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Profile.test.js
@@ -123,8 +123,7 @@ describe('<Profile>', () => {
         sampleValue: 'http://www.google.com',
         updateValue: 'http://www.sanrio.com',
         mutator: 'setProfileSettingsLink'
-      },
-
+      }
     ];
 
     configSets.forEach(function(config) {

--- a/packages/react-hig/src/elements/components/GlobalNav/SharedExamples.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/SharedExamples.js
@@ -33,6 +33,7 @@ class SharedExamples {
       attachTo: reactContainer
     });
 
+    expect(reactContainer.firstChild.outerHTML).toMatch(config.sampleValue);
     expect(reactContainer.firstChild.outerHTML).toMatchSnapshot();
     expect(reactContainer.firstChild.outerHTML).toEqual(
       higContainer.firstChild.outerHTML

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Profile.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/Profile.test.js.snap
@@ -29,7 +29,7 @@ exports[`<Profile> constructor has a good snapshot 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">charuvenki@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -70,10 +70,10 @@ exports[`<Profile> setting and updating props can set props for email 1`] = `
         <div class=\\"hig__flyout__panel\\">
             <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
-    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">foo@bar.baz</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">foo@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -117,7 +117,7 @@ exports[`<Profile> setting and updating props can set props for image 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -161,7 +161,139 @@ exports[`<Profile> setting and updating props can set props for name 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can set props for profileSettingsLabel 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Settings\\">Settings</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can set props for profileSettingsLink 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"http://www.google.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can set props for signOutLabel 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Logout\\">Logout</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -205,7 +337,7 @@ exports[`<Profile> setting and updating props can update props for email 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\" title=\\"hellokitty@example.com\\">hellokitty@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -239,7 +371,7 @@ exports[`<Profile> setting and updating props can update props for image 1`] = `
     <!--FLYOUT-->
 <div class=\\"hig__flyout\\">
     <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
-    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"/images/bar.jpg\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"/images/BAR.PNG\\">
 </div><!--TARGET-->
     <div class=\\"hig__flyout__container\\">
         <div class=\\"hig__flyout__chevron\\"></div>
@@ -249,7 +381,7 @@ exports[`<Profile> setting and updating props can update props for image 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>
@@ -293,7 +425,139 @@ exports[`<Profile> setting and updating props can update props for name 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can update props for profileSettingsLabel 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Preferences\\">Preferences</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can update props for profileSettingsLink 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"http://www.sanrio.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+    </div>
+</div><!--SLOT-->
+        </div>
+    </div>
+</div></div><!--PROFILE-->
+</div><!--TOPNAV-->
+        <!--SUBNAV-->
+        <div class=\\"hig__global-nav__slot\\">
+            <!--SLOT-->
+        </div>
+    </div>
+</div>"
+`;
+
+exports[`<Profile> setting and updating props can update props for signOutLabel 1`] = `
+"<div class=\\"hig__global-nav\\">
+    <!--SIDENAV-->
+    <div class=\\"hig__global-nav__container\\">
+        <div class=\\"hig__global-nav__top-nav\\">
+    <div class=\\"hig__global-nav__top-nav__group hig__global-nav__top-nav__group--left\\">
+        <div class=\\"hig__global-nav__top-nav__hamburger js-hig__global-nav__top-nav__hamburger\\"><div class=\\"hig__icon\\"><svg width=\\"30\\" height=\\"30\\" viewBox=\\"0 0 30 30\\" xmlns=\\"http://www.w3.org/2000/svg\\" role=\\"img\\" title=\\"hamburger\\"><g transform=\\"translate(-92 -185)\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><rect x=\\"92\\" y=\\"185\\" width=\\"30\\" height=\\"30\\"></rect><path d=\\"M100,195 L115,195 L115,196 L100,196 L100,195 Z M100,200 L115,200 L115,201 L100,201 L100,200 Z M100,205 L115,205 L115,206 L100,206 L100,205 Z\\" fill=\\"#34495E\\"></path></g></svg></div></div>
+        <div class=\\"hig__global-nav__top-nav__logo\\">
+            <a href=\\"#\\">
+                <img src=\\"link\\">
+            </a>
+        </div>
+    </div>
+    <div class=\\"hig__global-nav__top-nav__spacer\\"></div>
+    <!--PROJECT_ACCOUNT_SWITCHER-->
+    <div class=\\"hig__global-nav__profile hig__global-nav__top-nav__group--right\\">
+    <!--FLYOUT-->
+<div class=\\"hig__flyout\\">
+    <div class=\\"hig__global-nav__top-nav__profile__profile-image\\">
+    <img class=\\"hig__global-nav__top-nav__profile__profile-image__image\\" src=\\"https://placekitten.com/g/50/50\\">
+</div><!--TARGET-->
+    <div class=\\"hig__flyout__container\\">
+        <div class=\\"hig__flyout__chevron\\"></div>
+        <div class=\\"hig__flyout__panel\\">
+            <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content\\">
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__name\\">name</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
+    <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
+        <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>

--- a/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/TopNav.test.js.snap
+++ b/packages/react-hig/src/elements/components/GlobalNav/__snapshots__/TopNav.test.js.snap
@@ -29,7 +29,7 @@ exports[`<TopNav> renders a topnav 1`] = `
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__email\\">email@example.com</div>
     <div class=\\"src__components__global-nav__top-nav__profile__profile-flyout-content__links\\">
         <a href=\\"#\\" class=\\"hig__button hig__button--default\\" title=\\"Sign Out\\">Sign Out</a><!--SIGN_OUT_BUTTON-->
-        <a href=\\"#\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
+        <a href=\\"https://www.autodesk.com\\" class=\\"hig__button hig__button--link\\" title=\\"Profile Settings\\">Profile Settings</a><!--SETTINGS_LINK-->
     </div>
 </div><!--SLOT-->
         </div>

--- a/packages/react-hig/src/index.js
+++ b/packages/react-hig/src/index.js
@@ -155,7 +155,9 @@ class App extends React.Component {
             <Profile
               open={this.state.profileFlyoutOpen}
               image={profileImage}
-              signOutLabel="Logout"
+              signOutLabel="Sign Off"
+              profileSettingsLabel="Preferences"
+              profileSettingsLink="http://www.autodesk.com"
               onProfileImageClick={this.openProfileFlyout}
               onProfileClickOutside={this.closeProfileFlyout}
               onSignOutClick={this.profileSignOutClick}


### PR DESCRIPTION
Modify playground and unit tests to catch the setter failure from hig.web

<!--- Provide a general summary of your changes in the Title above -->

## Description, Motivation and Context
Does not fix #240, however, unit tests should have caught this. So I changed SharedExamples.js to catch a setter failure better, and I added more comprehensive tests to Profile.test.js

In the future, so long as there is a set & mutate test set up for a particular property in a component's unit tests, this change set should catch a failure to propagate the property setting down to the Hig web element and be reflected in the hig HTML template (or otherwise).

## How Has This Been Tested?
The breakage was in hig.web, not here in orion. After making these changes here in orion, I undid the bug fix in hig.web (by checking out master).  The test in question failed, reproducing issue #240.  When I put back the hig.web fix, the test passed again.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)  (well, sort of)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.