### PR TITLE
remove references to Container in storybook and add Tab, Tabs refs

### DIFF
--- a/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-*/
+ */
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -34,29 +34,96 @@ const ProjectAccountSwitcher = GlobalNav.TopNav.ProjectAccountSwitcher;
 const Account = GlobalNav.TopNav.ProjectAccountSwitcher.Account;
 const Project = GlobalNav.TopNav.ProjectAccountSwitcher.Project;
 const SubNav = GlobalNav.SubNav;
+const Tabs = GlobalNav.SubNav.Tabs;
+const Tab = GlobalNav.SubNav.Tabs.Tab;
 const Slot = GlobalNav.Slot;
 
 const LONG_COPY = (
   <div>
-    Raw denim flexitarian green juice kinfolk. Umami hammock trust fund everyday carry, woke wolf viral sriracha austin. Fingerstache affogato messenger bag salvia, cray iPhone bushwick blue bottle marfa gentrify dreamcatcher pop-up. Slow-carb etsy enamel pin cronut, raclette post-ironic hashtag. Hoodie dreamcatcher enamel pin lumbersexual before they sold out, authentic selvage tumblr vinyl. Hot chicken chillwave coloring book fixie vice venmo echo park portland. Tote bag master cleanse cronut banjo banh mi pitchfork, celiac photo booth.
+    <p>
+      Raw denim flexitarian green juice kinfolk. Umami hammock trust fund everyday carry, woke wolf viral sriracha austin.
+      Fingerstache affogato messenger bag salvia, cray iPhone bushwick blue bottle marfa gentrify dreamcatcher pop-up.
+      Slow-carb etsy enamel pin cronut, raclette post-ironic hashtag. Hoodie dreamcatcher enamel pin lumbersexual before
+      they sold out, authentic selvage tumblr vinyl. Hot chicken chillwave coloring book fixie vice venmo echo park
+      portland. Tote bag master cleanse cronut banjo banh mi pitchfork, celiac photo booth.
+    </p>
 
-    Next level deep v roof party, jianbing pok pok pug butcher vape farm-to-table kombucha. Yr snackwave VHS, wolf poutine actually woke poke flexitarian paleo food truck DIY kale chips viral yuccie. Cornhole tattooed vaporware affogato, gentrify mlkshk portland organic. Swag try-hard cronut hashtag, etsy bespoke chia banjo messenger bag. Mustache umami godard man braid cronut yuccie. YOLO vaporware franzen, gochujang typewriter mixtape brunch salvia paleo lyft. Four dollar toast tumblr mustache thundercats single-origin coffee, freegan flexitarian cold-pressed beard roof party VHS venmo af ugh bushwick.
+    <p>
+      Next level deep v roof party, jianbing pok pok pug butcher vape farm-to-table kombucha. Yr snackwave VHS, wolf
+      poutine actually woke poke flexitarian paleo food truck DIY kale chips viral yuccie. Cornhole tattooed vaporware
+      affogato, gentrify mlkshk portland organic. Swag try-hard cronut hashtag, etsy bespoke chia banjo messenger bag.
+      Mustache umami godard man braid cronut yuccie. YOLO vaporware franzen, gochujang typewriter mixtape brunch salvia
+      paleo lyft. Four dollar toast tumblr mustache thundercats single-origin coffee, freegan flexitarian cold-pressed
+      beard roof party VHS venmo af ugh bushwick.
+    </p>
 
-    Ethical man bun shoreditch chambray farm-to-table. Celiac readymade tote bag shabby chic chia, franzen poke meggings pop-up williamsburg VHS. Flexitarian cardigan blog yuccie activated charcoal farm-to-table. Iceland activated charcoal aesthetic, chambray offal snackwave austin four loko stumptown roof party humblebrag. Food truck selfies vexillologist, subway tile direct trade fingerstache tofu biodiesel four dollar toast. Literally squid tattooed jean shorts, raw denim echo park blog mustache skateboard seitan XOXO lo-fi cray hammock shabby chic. Live-edge sustainable pug, pinterest celiac kinfolk wayfarers narwhal art party vegan +1.
+    <p>
+      Ethical man bun shoreditch chambray farm-to-table. Celiac readymade tote bag shabby chic chia, franzen poke meggings
+      pop-up williamsburg VHS. Flexitarian cardigan blog yuccie activated charcoal farm-to-table. Iceland activated
+      charcoal aesthetic, chambray offal snackwave austin four loko stumptown roof party humblebrag. Food truck selfies
+      vexillologist, subway tile direct trade fingerstache tofu biodiesel four dollar toast. Literally squid tattooed jean
+      shorts, raw denim echo park blog mustache skateboard seitan XOXO lo-fi cray hammock shabby chic. Live-edge
+      sustainable pug, pinterest celiac kinfolk wayfarers narwhal art party vegan +1.
+    </p>
 
-    Helvetica DIY portland, sriracha selvage wolf beard plaid quinoa vegan flexitarian poke. Semiotics fam scenester, plaid synth listicle flexitarian subway tile. Cred everyday carry pop-up, forage viral tbh tilde mustache roof party leggings gastropub unicorn synth. Brunch hoodie williamsburg, selfies plaid jianbing deep v lomo truffaut meggings dreamcatcher kitsch. Mustache deep v fap hashtag, freegan quinoa blue bottle green juice helvetica pickled cronut. Photo booth 90's microdosing vexillologist roof party stumptown. Viral hella pitchfork, aesthetic intelligentsia godard hoodie plaid migas iPhone mlkshk tumeric keffiyeh.
+    <p>
+      Helvetica DIY portland, sriracha selvage wolf beard plaid quinoa vegan flexitarian poke. Semiotics fam scenester,
+      plaid synth listicle flexitarian subway tile. Cred everyday carry pop-up, forage viral tbh tilde mustache roof party
+      leggings gastropub unicorn synth. Brunch hoodie williamsburg, selfies plaid jianbing deep v lomo truffaut meggings
+      dreamcatcher kitsch. Mustache deep v fap hashtag, freegan quinoa blue bottle green juice helvetica pickled cronut.
+      Photo booth 90's microdosing vexillologist roof party stumptown. Viral hella pitchfork, aesthetic intelligentsia
+      godard hoodie plaid migas iPhone mlkshk tumeric keffiyeh.
+    </p>
 
-    Banh mi pug fanny pack heirloom portland. Humblebrag selvage forage vape organic beard bicycle rights, fam gentrify live-edge. Vape artisan truffaut, celiac prism XOXO drinking vinegar pour-over vinyl chambray lyft venmo. Tattooed edison bulb air plant hot chicken meggings cold-pressed gastropub, tbh tilde hoodie photo booth leggings. Etsy post-ironic fap you probably haven't heard of them, helvetica synth kinfolk listicle mixtape keytar cold-pressed. 90's put a bird on it yr godard prism kogi, live-edge enamel pin hell of photo booth. Raclette portland humblebrag synth af, fashion axe fingerstache ethical snackwave post-ironic cray.
+    <p>
+      Banh mi pug fanny pack heirloom portland. Humblebrag selvage forage vape organic beard bicycle rights, fam gentrify
+      live-edge. Vape artisan truffaut, celiac prism XOXO drinking vinegar pour-over vinyl chambray lyft venmo. Tattooed
+      edison bulb air plant hot chicken meggings cold-pressed gastropub, tbh tilde hoodie photo booth leggings. Etsy
+      post-ironic fap you probably haven't heard of them, helvetica synth kinfolk listicle mixtape keytar cold-pressed.
+      90's put a bird on it yr godard prism kogi, live-edge enamel pin hell of photo booth. Raclette portland humblebrag
+      synth af, fashion axe fingerstache ethical snackwave post-ironic cray.
+    </p>
 
-    Messenger bag listicle skateboard normcore. Roof party food truck authentic dreamcatcher lumbersexual ramps. Man bun drinking vinegar mixtape, disrupt sartorial cray lumbersexual bicycle rights fam brunch celiac lyft. Hella edison bulb poke thundercats taxidermy twee. Lomo biodiesel la croix, pitchfork normcore prism godard coloring book cornhole locavore helvetica. Everyday carry distillery tousled, bespoke irony chartreuse lumbersexual fixie. Unicorn asymmetrical tacos poke, tote bag disrupt sriracha coloring book.
+    <p>
+      Messenger bag listicle skateboard normcore. Roof party food truck authentic dreamcatcher lumbersexual ramps. Man bun
+      drinking vinegar mixtape, disrupt sartorial cray lumbersexual bicycle rights fam brunch celiac lyft. Hella edison
+      bulb poke thundercats taxidermy twee. Lomo biodiesel la croix, pitchfork normcore prism godard coloring book
+      cornhole locavore helvetica. Everyday carry distillery tousled, bespoke irony chartreuse lumbersexual fixie. Unicorn
+      asymmetrical tacos poke, tote bag disrupt sriracha coloring book.
+    </p>
 
-    Humblebrag narwhal hammock, cornhole biodiesel lomo vegan twee migas enamel pin iPhone vaporware chicharrones vape wolf. Godard XOXO deep v tbh irony, church-key seitan fixie post-ironic asymmetrical literally put a bird on it. Hell of helvetica cornhole lomo forage. Affogato activated charcoal ugh, +1 vape poutine poke artisan listicle before they sold out brunch prism VHS cronut. Craft beer PBR&B vice, synth XOXO green juice bitters narwhal chicharrones pinterest microdosing intelligentsia wayfarers scenester schlitz. Stumptown synth bicycle rights ugh poke, photo booth quinoa cronut pickled meggings tumeric. Yr wayfarers mustache pitchfork, art party bitters craft beer single-origin coffee.
+    <p>
+      Humblebrag narwhal hammock, cornhole biodiesel lomo vegan twee migas enamel pin iPhone vaporware chicharrones vape
+      wolf. Godard XOXO deep v tbh irony, church-key seitan fixie post-ironic asymmetrical literally put a bird on it.
+      Hell of helvetica cornhole lomo forage. Affogato activated charcoal ugh, +1 vape poutine poke artisan listicle
+      before they sold out brunch prism VHS cronut. Craft beer PBR&B vice, synth XOXO green juice bitters narwhal
+      chicharrones pinterest microdosing intelligentsia wayfarers scenester schlitz. Stumptown synth bicycle rights ugh
+      poke, photo booth quinoa cronut pickled meggings tumeric. Yr wayfarers mustache pitchfork, art party bitters craft
+      beer single-origin coffee.
+    </p>
 
-    Helvetica keytar leggings beard single-origin coffee, mustache organic pabst lumbersexual chartreuse art party waistcoat wolf mixtape 8-bit. Craft beer meggings subway tile hashtag, put a bird on it portland 8-bit cardigan knausgaard. Snackwave try-hard dreamcatcher, XOXO freegan iceland kinfolk readymade microdosing typewriter vegan vinyl live-edge hella direct trade. Heirloom flexitarian brunch, subway tile beard leggings hella echo park kinfolk poutine mustache cold-pressed. Copper mug marfa crucifix, kale chips bitters XOXO disrupt four dollar toast gluten-free scenester farm-to-table. 8-bit YOLO pickled photo booth biodiesel bushwick, gentrify ennui hoodie bespoke poutine twee tumblr cornhole tilde. Hammock authentic cold-pressed, chartreuse messenger bag blue bottle four dollar toast DIY raw denim cray squid poke biodiesel lo-fi taxidermy.
+    Helvetica keytar leggings beard single-origin coffee, mustache organic pabst lumbersexual chartreuse art party
+    waistcoat wolf mixtape 8-bit. Craft beer meggings subway tile hashtag, put a bird on it portland 8-bit cardigan
+    knausgaard. Snackwave try-hard dreamcatcher, XOXO freegan iceland kinfolk readymade microdosing typewriter vegan
+    vinyl live-edge hella direct trade. Heirloom flexitarian brunch, subway tile beard leggings hella echo park kinfolk
+    poutine mustache cold-pressed. Copper mug marfa crucifix, kale chips bitters XOXO disrupt four dollar toast
+    gluten-free scenester farm-to-table. 8-bit YOLO pickled photo booth biodiesel bushwick, gentrify ennui hoodie
+    bespoke poutine twee tumblr cornhole tilde. Hammock authentic cold-pressed, chartreuse messenger bag blue bottle
+    four dollar toast DIY raw denim cray squid poke biodiesel lo-fi taxidermy.
 
-    Messenger bag cardigan schlitz meggings pinterest, ramps whatever keytar taxidermy four loko PBR&B XOXO vaporware DIY direct trade. Occupy banjo succulents tacos, cred raw denim neutra chicharrones actually kickstarter food truck artisan paleo tumblr. Vinyl synth migas shabby chic, whatever shoreditch brooklyn deep v. 90's gochujang retro shoreditch, leggings banh mi dreamcatcher freegan four dollar toast unicorn kogi. Locavore scenester leggings cronut. Forage irony slow-carb plaid fap af. Art party asymmetrical typewriter trust fund, lyft skateboard gastropub small batch artisan squid iceland vegan disrupt master cleanse.
+    Messenger bag cardigan schlitz meggings pinterest, ramps whatever keytar taxidermy four loko PBR&B XOXO vaporware
+    DIY direct trade. Occupy banjo succulents tacos, cred raw denim neutra chicharrones actually kickstarter food truck
+    artisan paleo tumblr. Vinyl synth migas shabby chic, whatever shoreditch brooklyn deep v. 90's gochujang retro
+    shoreditch, leggings banh mi dreamcatcher freegan four dollar toast unicorn kogi. Locavore scenester leggings
+    cronut. Forage irony slow-carb plaid fap af. Art party asymmetrical typewriter trust fund, lyft skateboard gastropub
+    small batch artisan squid iceland vegan disrupt master cleanse.
 
-    Scenester fingerstache kitsch post-ironic snackwave, plaid microdosing gastropub whatever. Next level truffaut swag, offal health goth franzen craft beer tousled 90's retro cardigan man bun keffiyeh ugh. Vegan offal tumblr, distillery prism venmo iPhone 90's vaporware 8-bit cronut semiotics. Prism distillery leggings austin selvage mustache. Venmo gentrify schlitz, ennui cred master cleanse umami sustainable freegan. Chartreuse yuccie freegan, poke four dollar toast echo park messenger bag shabby chic bespoke waistcoat glossier. Offal intelligentsia keffiyeh, XOXO waistcoat neutra squid brunch pug tumeric man braid knausgaard.
+    Scenester fingerstache kitsch post-ironic snackwave, plaid microdosing gastropub whatever. Next level truffaut swag,
+    offal health goth franzen craft beer tousled 90's retro cardigan man bun keffiyeh ugh. Vegan offal tumblr,
+    distillery prism venmo iPhone 90's vaporware 8-bit cronut semiotics. Prism distillery leggings austin selvage
+    mustache. Venmo gentrify schlitz, ennui cred master cleanse umami sustainable freegan. Chartreuse yuccie freegan,
+    poke four dollar toast echo park messenger bag shabby chic bespoke waistcoat glossier. Offal intelligentsia
+    keffiyeh, XOXO waistcoat neutra squid brunch pug tumeric man braid knausgaard.
   </div>
 );
 
@@ -124,14 +191,12 @@ storiesOf('GlobalNav', module)
               <Account
                 image={project2}
                 label="Stanford hospital"
-                key="1"
                 active={false}
                 onClick={action('clicked')}
               />
               <Account
                 image=""
                 label="Oakland Medical Center"
-                key="2"
                 active={true}
                 onClick={action('clicked')}
               />
@@ -139,7 +204,6 @@ storiesOf('GlobalNav', module)
               <Project
                 image={project4}
                 label=""
-                key="3"
                 active={false}
                 onClick={action('clicked')}
               />
@@ -147,13 +211,12 @@ storiesOf('GlobalNav', module)
               <Project
                 image={project1}
                 label="Stanford hospital"
-                key="4"
                 active={false}
                 onClick={action('clicked')}
               />
             </ProjectAccountSwitcher>
-            <Shortcut icon="gear" title="GEAR" link="/settings" />
-            <Help title="HELLLP MEEEE!!!!" link="/help" />
+            <Shortcut icon="gear" title="GEAR" link="#" />
+            <Help title="HELLLP MEEEE!!!!" link="#`" />
             <Profile
               name="Jane Designer"
               email="jane.designer@example.com"
@@ -213,14 +276,12 @@ storiesOf('GlobalNav', module)
             <Account
               image={project2}
               label="Stanford hospital"
-              key="1"
               active={false}
               onClick={action('clicked')}
             />
             <Account
               image={project1}
               label="Oakland Medical Center"
-              key="2"
               active={true}
               onClick={action('clicked')}
             />
@@ -228,7 +289,6 @@ storiesOf('GlobalNav', module)
             <Project
               image=""
               label="California Pacific"
-              key="3"
               active={true}
               onClick={action('clicked')}
             />
@@ -236,7 +296,6 @@ storiesOf('GlobalNav', module)
             <Project
               image={project3}
               label="Stanford hospital"
-              key="4"
               active={false}
               onClick={action('clicked')}
             />
@@ -308,14 +367,12 @@ storiesOf('GlobalNav', module)
               </Section>
             </SectionList>
           </SideNav>
-          <Container>
-            <TopNav logo={logo} />
-            <SubNav
-              moduleIndicatorName="Insight"
-              moduleIndicatorIcon="hamburger"
-            />
-            <Slot>{LONG_COPY}</Slot>
-          </Container>
+          <TopNav logo={logo} />
+          <SubNav
+            moduleIndicatorName="Insight"
+            moduleIndicatorIcon="hamburger"
+          />
+          <Slot>{LONG_COPY}</Slot>
         </GlobalNav>
       );
     },
@@ -499,17 +556,15 @@ storiesOf('GlobalNav', module)
 
     return (
       <GlobalNav>
-        <Container>
-          <TopNav logo={logo} />
-          <SubNav moduleIndicatorName="Insight" moduleIndicatorIcon="hamburger">
-            <Tabs>
-              <Tab label="Audience" active={activeTab === 'Audience'} />
-              <Tab label="Acquisition" active={activeTab === 'Acquisition'} />
-              <Tab label="Behavior" active={activeTab === 'Behavior'} />
-            </Tabs>
-          </SubNav>
-          <Slot>{LONG_COPY}</Slot>
-        </Container>
+        <TopNav logo={logo} />
+        <SubNav moduleIndicatorName="Insight" moduleIndicatorIcon="hamburger">
+          <Tabs>
+            <Tab label="Audience" active={activeTab === 'Audience'} />
+            <Tab label="Acquisition" active={activeTab === 'Acquisition'} />
+            <Tab label="Behavior" active={activeTab === 'Behavior'} />
+          </Tabs>
+        </SubNav>
+        <Slot>{LONG_COPY}</Slot>
       </GlobalNav>
     );
   });


### PR DESCRIPTION
This mostly fixes a few glaring storybook sections and errors - there were still two Container elements and Tabs and Tab components had not been declared, and the links for Help and Shortcut caused bad behavior.  And some whitespacey things.