### PR TITLE
use objects and names rather than stringified versions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "code":   "100",
   "parser": "babel-eslint",
   "extends": [
     "prettier",

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/hig.web"]
 	path = packages/hig.web
-	url = git@github.com:adsk-hig/hig.web.git
+	url = git@github.com:Autodesk/hig.git

--- a/packages/react-hig/src/elements/HIGElement.js
+++ b/packages/react-hig/src/elements/HIGElement.js
@@ -139,5 +139,4 @@ export default class HIGElement {
       throw new Error('only one ' + name + ' is allowed');
     }
   }
-
 }

--- a/packages/react-hig/src/elements/HIGElement.js
+++ b/packages/react-hig/src/elements/HIGElement.js
@@ -140,10 +140,4 @@ export default class HIGElement {
     }
   }
 
-  checkValidChild(instance, validChildrenList) {
-    const name = instance.constructor.name;
-    if (!validChildrenList.includes(name)) {
-      throw new Error(name + ' is not a valid child element of this parent.');
-    }
-  }
 }

--- a/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
@@ -118,14 +118,12 @@ export class TopNav extends HIGElement {
   }
 
   checkValidChild(instance) {
-    const validInstances = [
-      Profile,
-      ProjectAccountSwitcher,
-      Shortcut,
-      Help
-    ];
+    const validInstances = [Profile, ProjectAccountSwitcher, Shortcut, Help];
     if (!validInstances.includes(instance.constructor)) {
-      throw new Error(instance.constructor.name + ' is not a valid child element of this parent.');
+      throw new Error(
+        instance.constructor.name +
+          ' is not a valid child element of this parent.'
+      );
     }
 
     //super.checkValidChild(instance, validInstances);

--- a/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/TopNav.js
@@ -119,12 +119,16 @@ export class TopNav extends HIGElement {
 
   checkValidChild(instance) {
     const validInstances = [
-      'Profile',
-      'ProjectAccountSwitcher',
-      'Shortcut',
-      'Help'
+      Profile,
+      ProjectAccountSwitcher,
+      Shortcut,
+      Help
     ];
-    super.checkValidChild(instance, validInstances);
+    if (!validInstances.includes(instance.constructor)) {
+      throw new Error(instance.constructor.name + ' is not a valid child element of this parent.');
+    }
+
+    //super.checkValidChild(instance, validInstances);
   }
   getPropertyNameFor(instance) {
     const initial = instance.constructor.name.charAt(0).toLowerCase();


### PR DESCRIPTION
## Description
Storybook was failing when pushed to the QA CDN.  It was not failing when build locally, except when built from the orion-ui root.

## How Has This Been Tested?
Locally run npm build from orion-ui root to reproduce the problem.
Open the storybook index file. 
With the fix, the storybook UI (left panel) comes back. Some things are still broken because there are issues due to changes in hig that need to be reflected in orion.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (not necessary, current tests cover changes)
- [ ] All new and existing tests passed.