### PR TITLE
Add samples to Playground and Storybook for Link

### DIFF
--- a/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
@@ -46,9 +46,12 @@ const Tab = GlobalNav.SubNav.Tabs.Tab;
 const Slot = GlobalNav.Slot;
 
 const links = [
-  {title: 'Autodesk Main', url: 'http://www.autodesk.com'},
-  {title: 'AutoCAD', url: 'https://www.autodesk.com/products/autocad/overview'},
-  {title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview'}
+  { title: 'Autodesk Main', url: 'http://www.autodesk.com' },
+  {
+    title: 'AutoCAD',
+    url: 'https://www.autodesk.com/products/autocad/overview'
+  },
+  { title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview' }
 ];
 const LONG_COPY = (
   <div>
@@ -184,7 +187,7 @@ storiesOf('GlobalNav', module)
         </SideNav>
         <TopNav logo={logo}>
           <ProjectAccountSwitcher
-            open={boolean(false)}
+            open={boolean('Project Account Switcher open:', false)}
             onProjectChange={action('Project activated')}
             onAccountChange={action('Account activated')}
           >
@@ -266,12 +269,14 @@ storiesOf('GlobalNav', module)
           </SectionList>
 
           <LinkList>
-            { links.map( (link, i) => {
+            {links.map((link, i) => {
               return (
-                <Link title={text(`Link ${i+1} title`, link.title)}
-                      link={link.url} key={i}
+                <Link
+                  title={text(`Link ${i + 1} title`, link.title)}
+                  link={link.url}
+                  key={i}
                 />
-              )
+              );
             })}
           </LinkList>
 
@@ -453,48 +458,52 @@ storiesOf('GlobalNav', module)
     );
   })
   .addWithInfo('SideNav open w/ custom hover/click Links', ``, () => {
-    return (<GlobalNav sideNavOpen={true}>
-      <SideNav>
-        <SectionList>
-          <Section headerLabel="Project" headerName="ThunderStorm">
-            <Group>
-              <Module icon="insight" title="Insight" key={'Insight'}>
-                <Submodule
-                  title="Overview"
-                  link="#"
-                  onClick={action('clicked')}
-                />
-                <Submodule
-                  title="Extreme Risk"
-                  link="#"
-                  onClick={action('clicked')}
-                />
-                <Submodule
-                  title="Calculated risk"
-                  link="#"
-                  onClick={action('clicked')}
-                />
-              </Module>
-            </Group>
-          </Section>
-        </SectionList>
-        <LinkList>
-          <Link title="Hello Kitty"
-                link="#"
-                onClick={ action("I was clicked") }
-          />
-          <Link title="Dear Daniel"
-                link="http://www.sanrio.com"
-                onHover={ action("I'm being hovered") }
-          />
-        </LinkList>
-        <Search placeholder="Find module or submodule" />
-      </SideNav>
-      <TopNav logo={logo} />
-      <SubNav moduleIndicatorName="Insight" moduleIndicatorIcon="hamburger" />
-      <Slot>{LONG_COPY}</Slot>
-    </GlobalNav>)
-  } )
+    return (
+      <GlobalNav sideNavOpen={true}>
+        <SideNav>
+          <SectionList>
+            <Section headerLabel="Project" headerName="ThunderStorm">
+              <Group>
+                <Module icon="insight" title="Insight" key={'Insight'}>
+                  <Submodule
+                    title="Overview"
+                    link="#"
+                    onClick={action('clicked')}
+                  />
+                  <Submodule
+                    title="Extreme Risk"
+                    link="#"
+                    onClick={action('clicked')}
+                  />
+                  <Submodule
+                    title="Calculated risk"
+                    link="#"
+                    onClick={action('clicked')}
+                  />
+                </Module>
+              </Group>
+            </Section>
+          </SectionList>
+          <LinkList>
+            <Link
+              title="Hello Kitty"
+              link="#"
+              onClick={action('I was clicked')}
+            />
+            <Link
+              title="Dear Daniel"
+              link="http://www.sanrio.com"
+              onHover={action("I'm being hovered")}
+            />
+          </LinkList>
+          <Search placeholder="Find module or submodule" />
+        </SideNav>
+        <TopNav logo={logo} />
+        <SubNav moduleIndicatorName="Insight" moduleIndicatorIcon="hamburger" />
+        <Slot>{LONG_COPY}</Slot>
+      </GlobalNav>
+    );
+  })
   .addWithInfo('? no children', ``, () => {
     const sideNavOpen = boolean('sideNavOpen', true);
     return <GlobalNav sideNavOpen={sideNavOpen} />;

--- a/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/GlobalNav.story.js
@@ -27,6 +27,8 @@ const SectionList = GlobalNav.SideNav.SectionList;
 const Section = GlobalNav.SideNav.SectionList.Section;
 const Collapse = GlobalNav.SideNav.SectionList.Section.SectionCollapse;
 const Group = GlobalNav.SideNav.SectionList.Section.Group;
+const LinkList = GlobalNav.SideNav.LinkList;
+const Link = GlobalNav.SideNav.LinkList.Link;
 const Module = GlobalNav.SideNav.SectionList.Section.Group.Module;
 const ModuleCollapse = GlobalNav.SideNav.SectionList.Section.Group.Module.ModuleCollapse;
 const Submodule = GlobalNav.SideNav.SectionList.Section.Group.Module.Submodule;
@@ -43,6 +45,11 @@ const Tabs = GlobalNav.SubNav.Tabs;
 const Tab = GlobalNav.SubNav.Tabs.Tab;
 const Slot = GlobalNav.Slot;
 
+const links = [
+  {title: 'Autodesk Main', url: 'http://www.autodesk.com'},
+  {title: 'AutoCAD', url: 'https://www.autodesk.com/products/autocad/overview'},
+  {title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview'}
+];
 const LONG_COPY = (
   <div>
     <p>
@@ -257,6 +264,17 @@ storiesOf('GlobalNav', module)
               </Group>
             </Section>
           </SectionList>
+
+          <LinkList>
+            { links.map( (link, i) => {
+              return (
+                <Link title={text(`Link ${i+1} title`, link.title)}
+                      link={link.url} key={i}
+                />
+              )
+            })}
+          </LinkList>
+
           <Search placeholder="Find module or submodule" />
         </SideNav>
         <TopNav logo={logo} />
@@ -434,6 +452,49 @@ storiesOf('GlobalNav', module)
       </GlobalNav>
     );
   })
+  .addWithInfo('SideNav open w/ custom hover/click Links', ``, () => {
+    return (<GlobalNav sideNavOpen={true}>
+      <SideNav>
+        <SectionList>
+          <Section headerLabel="Project" headerName="ThunderStorm">
+            <Group>
+              <Module icon="insight" title="Insight" key={'Insight'}>
+                <Submodule
+                  title="Overview"
+                  link="#"
+                  onClick={action('clicked')}
+                />
+                <Submodule
+                  title="Extreme Risk"
+                  link="#"
+                  onClick={action('clicked')}
+                />
+                <Submodule
+                  title="Calculated risk"
+                  link="#"
+                  onClick={action('clicked')}
+                />
+              </Module>
+            </Group>
+          </Section>
+        </SectionList>
+        <LinkList>
+          <Link title="Hello Kitty"
+                link="#"
+                onClick={ action("I was clicked") }
+          />
+          <Link title="Dear Daniel"
+                link="http://www.sanrio.com"
+                onHover={ action("I'm being hovered") }
+          />
+        </LinkList>
+        <Search placeholder="Find module or submodule" />
+      </SideNav>
+      <TopNav logo={logo} />
+      <SubNav moduleIndicatorName="Insight" moduleIndicatorIcon="hamburger" />
+      <Slot>{LONG_COPY}</Slot>
+    </GlobalNav>)
+  } )
   .addWithInfo('? no children', ``, () => {
     const sideNavOpen = boolean('sideNavOpen', true);
     return <GlobalNav sideNavOpen={sideNavOpen} />;

--- a/packages/react-hig/src/elements/components/GlobalNav/Link.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Link.js
@@ -27,7 +27,6 @@ export class Link extends HIGElement {
 
 const LinkComponent = createComponent(Link);
 
-
 LinkComponent.propTypes = {
   addTitle: PropTypes.func,
   addLink: PropTypes.func,
@@ -38,16 +37,16 @@ LinkComponent.propTypes = {
 LinkComponent.__docgenInfo = {
   props: {
     title: {
-      description: "Title {string} for the Link component"
+      description: 'Title {string} for the Link component'
     },
     link: {
-      description: "URL {string} for the Link component"
+      description: 'URL {string} for the Link component'
     },
     onClick: {
-      description: "{function} Triggered when user clicks on the link"
+      description: '{function} Triggered when user clicks on the link'
     },
     onHover: {
-      description: "{function} Triggered when user hovers over the link"
+      description: '{function} Triggered when user hovers over the link'
     }
   }
 };

--- a/packages/react-hig/src/elements/components/GlobalNav/Link.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/Link.js
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+import * as PropTypes from 'prop-types';
 import createComponent from '../../../adapters/createComponent';
 import HIGElement from '../../HIGElement';
 
@@ -25,5 +26,30 @@ export class Link extends HIGElement {
 }
 
 const LinkComponent = createComponent(Link);
+
+
+LinkComponent.propTypes = {
+  addTitle: PropTypes.func,
+  addLink: PropTypes.func,
+  onClick: PropTypes.func,
+  onHover: PropTypes.func
+};
+
+LinkComponent.__docgenInfo = {
+  props: {
+    title: {
+      description: "Title {string} for the Link component"
+    },
+    link: {
+      description: "URL {string} for the Link component"
+    },
+    onClick: {
+      description: "{function} Triggered when user clicks on the link"
+    },
+    onHover: {
+      description: "{function} Triggered when user hovers over the link"
+    }
+  }
+};
 
 export default LinkComponent;

--- a/packages/react-hig/src/elements/components/GlobalNav/LinkList.js
+++ b/packages/react-hig/src/elements/components/GlobalNav/LinkList.js
@@ -15,6 +15,7 @@ limitations under the License.
 
 */
 import createComponent from '../../../adapters/createComponent';
+import HIGChildValidator from '../../HIGChildValidator';
 import HIGNodeList from '../../HIGNodeList';
 
 import LinkComponent, { Link } from './Link';
@@ -59,6 +60,18 @@ export class LinkList {
 
 const LinkListComponent = createComponent(LinkList);
 
-LinkListComponent.Item = LinkComponent;
+LinkListComponent.propTypes = {
+  children: HIGChildValidator([LinkComponent])
+};
+
+LinkListComponent.__docgenInfo = {
+  props: {
+    children: {
+      description: 'support adding Link'
+    }
+  }
+};
+
+LinkListComponent.Link = LinkComponent;
 
 export default LinkListComponent;

--- a/packages/react-hig/src/index.js
+++ b/packages/react-hig/src/index.js
@@ -26,6 +26,8 @@ import profileImage from './images/profileImage.png';
 import TopNavFixtures from './fixtures/topNavFixtures';
 
 const SideNav = GlobalNav.SideNav;
+const LinkList = GlobalNav.SideNav.LinkList;
+const Link = GlobalNav.SideNav.LinkList.Link;
 const Search = GlobalNav.SideNav.Search;
 const SectionList = GlobalNav.SideNav.SectionList;
 const Section = GlobalNav.SideNav.SectionList.Section;
@@ -46,6 +48,12 @@ const Tab = GlobalNav.SubNav.Tabs.Tab;
 const Slot = GlobalNav.Slot;
 
 const topNavFixtures = new TopNavFixtures();
+
+const links = [
+  {title: 'Autodesk Main', url: 'http://www.autodesk.com'},
+  {title: 'AutoCAD', url: 'https://www.autodesk.com/products/autocad/overview'},
+  {title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview'}
+];
 
 class App extends React.Component {
   constructor() {
@@ -112,6 +120,13 @@ class App extends React.Component {
       <div>
         <GlobalNav>
           <SideNav>
+            <LinkList>
+              { links.map( (link, i) => {
+                return (
+                  <Link title={link.title} link={link.url} key={i} />
+                )
+              })}
+            </LinkList>
             <SectionList>
               <Section headerLabel="Project" headerName="ThunderStorm">
                 {topNavFixtures.menu().sections[0].groups.map((group, i) => {

--- a/packages/react-hig/src/index.js
+++ b/packages/react-hig/src/index.js
@@ -50,9 +50,12 @@ const Slot = GlobalNav.Slot;
 const topNavFixtures = new TopNavFixtures();
 
 const links = [
-  {title: 'Autodesk Main', url: 'http://www.autodesk.com'},
-  {title: 'AutoCAD', url: 'https://www.autodesk.com/products/autocad/overview'},
-  {title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview'}
+  { title: 'Autodesk Main', url: 'http://www.autodesk.com' },
+  {
+    title: 'AutoCAD',
+    url: 'https://www.autodesk.com/products/autocad/overview'
+  },
+  { title: 'Maya', url: 'https://www.autodesk.com/products/maya/overview' }
 ];
 
 class App extends React.Component {
@@ -121,10 +124,8 @@ class App extends React.Component {
         <GlobalNav>
           <SideNav>
             <LinkList>
-              { links.map( (link, i) => {
-                return (
-                  <Link title={link.title} link={link.url} key={i} />
-                )
+              {links.map((link, i) => {
+                return <Link title={link.title} link={link.url} key={i} />;
               })}
             </LinkList>
             <SectionList>


### PR DESCRIPTION
## Description
One reference to "Item" had to be changed to "Link."  Otherwise these are all documentation type changes.  An update to Hig was required because there was some missing styling.

## Motivation and Context
#224 Add sample for Links

### SideNav open story
![screen shot 2017-07-06 at 2 48 34 pm](https://user-images.githubusercontent.com/502640/27934657-8f064f9c-625b-11e7-980f-ded30356e127.png)

### Customized Link events story
![screen shot 2017-07-06 at 2 49 03 pm](https://user-images.githubusercontent.com/502640/27934660-90e63250-625b-11e7-9039-1c7dd7ddc561.png)

### Playground
![playground](https://user-images.githubusercontent.com/502640/27934654-8b1bfe9a-625b-11e7-953a-2133b2b7b033.gif)

## How Has This Been Tested?
* Ran playground, ran storybook
* One story allows updating of title via knobs
* One story customizes onClick and onHover events.
* These are isolated changes and should not affect any other components.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.