### PR TITLE
fix component reference to proptypes so they show up in storybook

### DIFF
--- a/packages/react-hig/src/adapters/FormElements/CheckboxAdapter.js
+++ b/packages/react-hig/src/adapters/FormElements/CheckboxAdapter.js
@@ -102,7 +102,7 @@ export class CheckboxAdapter extends HIGElement {
 
 const CheckboxAdapterComponent = createComponent(CheckboxAdapter);
 
-CheckboxAdapter.propTypes = {
+CheckboxAdapterComponent.propTypes = {
   disabled: PropTypes.bool,
   checked: PropTypes.bool,
   required: PropTypes.bool,

--- a/packages/react-hig/src/adapters/TextFieldAdapter.js
+++ b/packages/react-hig/src/adapters/TextFieldAdapter.js
@@ -124,7 +124,7 @@ class TextFieldAdapter extends HIGElement {
 
 const TextFieldComponent = createComponent(TextFieldAdapter);
 
-TextFieldAdapter.propTypes = {
+TextFieldComponent.propTypes = {
   disabled: PropTypes.bool,
   icon: PropTypes.string,
   instructions: PropTypes.string,
@@ -139,7 +139,7 @@ TextFieldAdapter.propTypes = {
   value: PropTypes.string
 };
 
-TextFieldAdapter.__docgenInfo = {
+TextFieldComponent.__docgenInfo = {
   props: {
     disabled: {
       description: 'prevents interaction with the text field'

--- a/packages/react-hig/src/elements/basics/Button.js
+++ b/packages/react-hig/src/elements/basics/Button.js
@@ -47,7 +47,7 @@ class Button extends HIGElement {
 
 const ButtonComponent = createComponent(Button);
 
-Button.propTypes = {
+ButtonComponent.propTypes = {
   disabled: PropTypes.bool,
   link: PropTypes.string,
   onBlur: PropTypes.func,

--- a/packages/react-hig/src/elements/basics/IconButton.js
+++ b/packages/react-hig/src/elements/basics/IconButton.js
@@ -121,7 +121,7 @@ class IconButton extends HIGElement {
 
 const IconButtonComponent = createComponent(IconButton);
 
-IconButton.propTypes = {
+IconButtonComponent.propTypes = {
   title: PropTypes.string,
   icon: PropTypes.string,
   disabled: PropTypes.bool,


### PR DESCRIPTION
## Description
Fix component reference to PropTypes so that they show up in storybook.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.